### PR TITLE
some fixes needed on my machine

### DIFF
--- a/MVEE/Src/MVEE_logging.cpp
+++ b/MVEE/Src/MVEE_logging.cpp
@@ -539,7 +539,7 @@ void monitor::log_variant_backtrace(int variantnum, int max_depth, int calculate
 				{
 					logfunc("%s - >>> Process terminated by signal: %s\n",
 							call_get_variant_pidstr(variantnum).c_str(), getTextualSig(status.data));
-					if (WTERMSIG(status) != SIGSEGV)
+					if (status.data != SIGSEGV)
 					{
 						set_mmap_table->release_lock();
 						return;

--- a/make-common
+++ b/make-common
@@ -39,7 +39,7 @@ SRCS	 = $(SRC) $(ARCH_SRC)
 # Common build config
 #-----------------------------------------------------------------------------
 
-STD_CXXFLAGS = -D__LINUX_X86__ -Wall -Werror -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-function -Ideps/jsoncpp/include/
+STD_CXXFLAGS = -D__LINUX_X86__ -Wall -Werror -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-function -Ideps/jsoncpp/include/ -Ideps/libdwarf/libdwarf
 STD_LDFLAGS  = deps/jsoncpp/build/src/lib_json/libjsoncpp.a deps/libdwarf/libdwarf/libdwarf.a deps/libelf/lib/libelf.a -ldl -lrt -lstdc++ -lpthread -lz 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Hey, on my machine (Ubuntu 16.04) I needed a few fixes for this to build. Not entirely sure why -- I could swear just last week I got this building without modifications on a 16.04 VM.

The WTERMSIG call patch especially deserves an extra eyeball. I *think* that by the time we reach this codepoint the guy who constructed the status should already have called WTERMSIG for us already, but somebody who's more familiar with the guts should verify that this is indeed the intended behavior. (Also it seems strange to me that this ever compiled, which makes me extra confused about whether this is the right fix or not.)